### PR TITLE
Fix .net45 bug #495 with slow WriteAsync, specially on WebSockets

### DIFF
--- a/src/StreamExtended/Network/CustomBufferedStream.cs
+++ b/src/StreamExtended/Network/CustomBufferedStream.cs
@@ -580,6 +580,7 @@ namespace StreamExtended.Network
             buffer = newBuffer;
         }
 
+#if NET45
         /// <summary>
         /// Fix the .net bug with SslStream slow WriteAsync
         /// https://github.com/justcoding121/Titanium-Web-Proxy/issues/495
@@ -595,5 +596,6 @@ namespace StreamExtended.Network
         {
             baseStream.EndWrite(asyncResult);
         }
+#endif
     }
 }


### PR DESCRIPTION
Fix the infamous bug https://github.com/justcoding121/Titanium-Web-Proxy/issues/495

Fact : Stream.BeginWrite + Stream.BeginRead uses the same SemaphoreSlim(1)
It's not adapted for tunneling because Read can wait for 10 seconds before you can Write.

That's why we need to override BeginWrite/EndWrite  in CustomBufferedStream and calling NetworkStream.BeginWrite instead of Stream.BeginWrite (it's ok to not override BeginRead because it will not interfer with Network.BeginWrite which doesn't use the Semaphore)

So it's time to remove ifdef NET45 and use Async only :)

Check the Send speed on : https://www.websocket.org/echo.html