### PR TITLE
Fix ThreadPool Blocking (no more need to make grow ThreadPool manually)

### DIFF
--- a/src/StreamExtended/TaskExtended.cs
+++ b/src/StreamExtended/TaskExtended.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StreamExtended
+{
+    /// <summary>
+    /// Mimic a Task<T> but you can set AsyncState
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class TaskExtended<T> : IAsyncResult
+    {
+        Task<T> Task;
+        object mAsyncState;
+
+        public TaskExtended(Task<T> pTask, object state)
+        {
+            Task = pTask;
+            mAsyncState = state;
+        }
+
+        public object AsyncState => mAsyncState;
+        public WaitHandle AsyncWaitHandle => ((IAsyncResult)Task).AsyncWaitHandle;
+        public bool CompletedSynchronously => ((IAsyncResult)Task).CompletedSynchronously;
+        public bool IsCompleted => Task.IsCompleted;
+        public T Result => Task.Result;
+    }
+}


### PR DESCRIPTION
Fix the infamous Thread Blocking bug when Reading (default Stream.BeginRead uses Stream.Read => yuck). 
Override BeginRead/EndRead with a little magic did the trick.

Titanium is now fully async/await compliant :)
I already sent a PR in Titanium to remove the ThreadPool workaround.