### PR TITLE
Memory Leak Fix + New method in interface ICustomStreamReader

### DIFF
--- a/src/StreamExtended/Network/CopyStream.cs
+++ b/src/StreamExtended/Network/CopyStream.cs
@@ -54,6 +54,11 @@ namespace StreamExtended.Network
             return reader.PeekByteAsync(index, cancellationToken);
         }
 
+        public Task<byte[]> PeekBytesAsync(int index, int size, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return reader.PeekBytesAsync(index, size, cancellationToken);
+        }
+
         public void Flush()
         {
             //send out the current data from from the buffer

--- a/src/StreamExtended/Network/CustomBufferedPeekStream.cs
+++ b/src/StreamExtended/Network/CustomBufferedPeekStream.cs
@@ -86,6 +86,17 @@ namespace StreamExtended.Network
         }
 
         /// <summary>
+        /// Peeks bytes asynchronous.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        Task<byte[]> ICustomStreamReader.PeekBytesAsync(int index, int size, CancellationToken cancellationToken)
+        {
+            return baseStream.PeekBytesAsync(index, size, cancellationToken);
+        }
+
+        /// <summary>
         /// Peeks a byte asynchronous.
         /// </summary>
         /// <param name="index">The index.</param>

--- a/src/StreamExtended/Network/CustomBufferedStream.cs
+++ b/src/StreamExtended/Network/CustomBufferedStream.cs
@@ -432,6 +432,7 @@ namespace StreamExtended.Network
                 else
                 {
                     closed = true;
+                    throw new IOException($"{nameof(CustomBufferedStream)} closed");
                 }
 
                 return result;
@@ -439,7 +440,7 @@ namespace StreamExtended.Network
             catch
             {
                 closed = true;
-                return false;
+                throw;//rethrow
             }
         }
 
@@ -481,6 +482,7 @@ namespace StreamExtended.Network
                 else
                 {
                     closed = true;
+                    throw new IOException($"{nameof(CustomBufferedStream)} closed");
                 }
 
                 return result;
@@ -488,7 +490,7 @@ namespace StreamExtended.Network
             catch
             {
                 closed = true;
-                return false;
+                throw;//rethrow
             }
         }
 

--- a/src/StreamExtended/Network/CustomBufferedStream.cs
+++ b/src/StreamExtended/Network/CustomBufferedStream.cs
@@ -241,6 +241,30 @@ namespace StreamExtended.Network
         }
 
         /// <summary>
+        /// Peeks bytes asynchronous.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        public async Task<byte[]> PeekBytesAsync(int index, int size, CancellationToken cancellationToken = default(CancellationToken))
+        {
+
+            if (Available <= index)
+            {
+                await FillBufferAsync(cancellationToken);
+            }
+
+            if (Available <= (index + size))
+            {
+                return null;
+            }
+
+            var vRet = new byte[size];
+            Array.Copy(streamBuffer, index, vRet, 0, size);
+            return vRet;
+        }
+
+        /// <summary>
         /// Peeks a byte from buffer.
         /// </summary>
         /// <param name="index">The index.</param>

--- a/src/StreamExtended/Network/ICustomStreamReader.cs
+++ b/src/StreamExtended/Network/ICustomStreamReader.cs
@@ -37,6 +37,14 @@ namespace StreamExtended.Network
         /// <returns></returns>
         Task<int> PeekByteAsync(int index, CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// Peeks bytes asynchronous.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        Task<byte[]> PeekBytesAsync(int index, int size, CancellationToken cancellationToken = default(CancellationToken));
+
         byte ReadByteFromBuffer();
 
         /// <summary>


### PR DESCRIPTION
I found a big memory leak when using with Titanium because the Stream said it's closed when reading 0 bytes

     try
     {
          int readBytes = baseStream.Read(streamBuffer, bufferLength, streamBuffer.Length - bufferLength);
          bool result = readBytes > 0;
          if (result)
          {
              OnDataRead(streamBuffer, bufferLength, readBytes);
              bufferLength += readBytes;
          }
          else
          {
               closed = true; //need to throw here
          }
          return result;
      }
      catch
      {
          closed = true; //need to re-throw here 
          return false;
      }

but without throwing an Exception, the stream is in a zombie state, relayed to cache and nobody can read on it because closed = true...

I also add a new method PeekBytesAsync in ICustomStreamReader, I will use it later in Titanium to optimize code (instead of reading byte per byte)